### PR TITLE
Have our fork use it's own module name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ manual_test.go
 *.err
 
 .vscode
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
-module github.com/PaesslerAG/jsonpath
+module github.com/pendo-io/jsonpath
 
-require github.com/PaesslerAG/gval v0.1.0
+require (
+	github.com/PaesslerAG/gval v1.0.0
+	github.com/PaesslerAG/jsonpath v0.1.1
+)
+
+go 1.12
+
+replace github.com/PaesslerAG/jsonpath => github.com/pendo-io/jsonpath v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,7 @@
 github.com/PaesslerAG/gval v0.1.0 h1:XxyoMWvLhTNiRcXg2dsG0LaOMcRTh22doPMWYLAe528=
 github.com/PaesslerAG/gval v0.1.0/go.mod h1:jjpVgM2F5GvUIHLM66Z4B4tyojnCW8kh/QY68RpHucQ=
+github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
+github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
+github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
+github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
+github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=


### PR DESCRIPTION
Why?

When this is pulled in from pendo-appengine, go will complain that the module does not match the path. A lot of our packages in goexternal are our forks, "disguised" as upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/jsonpath/1)
<!-- Reviewable:end -->
